### PR TITLE
closeTab function workaround

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -64,6 +64,7 @@ const initialState: State = {
 class App extends Component<{}, State> {
   constructor(props: {}) {
     super(props);
+    // Copy of initial state object
     this.state = initialState;
   }
 
@@ -112,6 +113,8 @@ class App extends Component<{}, State> {
   };
 
   convertAndStoreYamlJSON = (yamlText: string, filePath: string) => {
+    // Make copy of current state
+    const currentState = { ...initialState };
     const yamlJSON = yaml.safeLoad(yamlText);
     const yamlState = convertYamlToState(yamlJSON, filePath);
     const openFiles = this.state.openFiles.slice()
@@ -124,7 +127,7 @@ class App extends Component<{}, State> {
     // store opened file state in localStorage under the current state item call "state" as well as an individual item using the filePath as the key.
     localStorage.setItem('state', JSON.stringify(yamlState));
     localStorage.setItem(`${filePath}`, JSON.stringify(yamlState));
-    this.setState(Object.assign(initialState, yamlState, { openFiles }));
+    this.setState(Object.assign(currentState, yamlState, { openFiles }));
   };
 
   /**
@@ -135,6 +138,7 @@ class App extends Component<{}, State> {
    * ** if errors, passes error string to handle file open errors method
    */
   fileOpen: FileOpen = (file: File) => {
+    console.log('Opening file')
     const fileReader = new FileReader();
     // check for valid file path
     if (file.path) {
@@ -147,7 +151,7 @@ class App extends Component<{}, State> {
           fileReader.onload = () => {
             // if successful read, invoke method to convert and store to state
             if (fileReader.result) {
-              console.log('fileReader.result: ', fileReader.result)
+              // console.log('fileReader.result: ', fileReader.result)
               let yamlText = fileReader.result.toString();
               //if docker-compose uses env file, replace the variables with value from env file
               if (validationResults.envResolutionRequired) {
@@ -170,12 +174,12 @@ class App extends Component<{}, State> {
    * associated with the given filePath. 
    */
   switchToTab: SwitchTab = (filePath: string) => {
-    const currentState = Object.assign({}, this.state)
-    const tabState = JSON.parse(localStorage.getItem(filePath) || '{}')
-    const newState = Object.assign({}, currentState, tabState)
+    const currentState = {...this.state};
+    const tabState = JSON.parse(localStorage.getItem(filePath) || '{}');
+    const newState = Object.assign({}, currentState, tabState);
     localStorage.setItem('state', JSON.stringify(tabState));
     window.d3State = setD3State(newState.services);
-    this.setState(newState)
+    this.setState(newState);
   }
 
   /**
@@ -184,24 +188,33 @@ class App extends Component<{}, State> {
    * @description removes the tab corresponding to the given file path 
    */
   closeTab: SwitchTab = (filePath: string) => {
-    const currentState = Object.assign({}, this.state);
+    const currentState = { ...this.state };
     const { openFiles } = currentState;
     // const index = openFiles.indexOf(filePath);
-    const newOpenFiles = openFiles.filter(file => file != filePath
-    );
+    const newOpenFiles = openFiles.filter(file => file != filePath);
     localStorage.removeItem(filePath);
-    console.log('newOpenFiles: ', newOpenFiles)
-    if (newOpenFiles.length) {
-      const nextTabState = JSON.parse(localStorage.getItem(newOpenFiles[0]) || '{}')
-      localStorage.setItem('state', JSON.stringify(nextTabState));
-      const newState = Object.assign(currentState, nextTabState, { openFiles: newOpenFiles })
-      window.d3State = setD3State(newState.services)
-      this.setState(newState)
-    } else {
-      localStorage.removeItem('state')
-      window.d3State = setD3State({})
-      this.setState(initialState)
-    }
+    localStorage.removeItem('state');
+    window.d3State = setD3State({})
+    this.setState({...initialState, openFiles: newOpenFiles})
+
+    // console.log('newOpenFiles: ', newOpenFiles)
+    // console.log('length', newOpenFiles.length)
+    // if (newOpenFiles.length) {
+    //   console.log('Has length')
+    //   const nextTabState = JSON.parse(localStorage.getItem(newOpenFiles[index - 1]) || '{}')
+    //   localStorage.setItem('state', JSON.stringify(nextTabState));
+    //   const newState = Object.assign(currentState, nextTabState, { openFiles: newOpenFiles })
+    //   window.d3State = setD3State(newState.services)
+    //   this.setState(newState)
+    // } else {
+    //   console.log('Doesn\'t have length')
+    //   localStorage.removeItem('state')
+    //   // console.log('State removed')
+    //   window.d3State = setD3State({})
+    //   // console.log('d3state set')
+    //   // console.log('This is the initial state: ', initialState)
+    //   this.setState(initialState)
+    // }
   }
 
   /**
@@ -219,6 +232,7 @@ class App extends Component<{}, State> {
   };
 
   componentDidMount() {
+    console.log('ipcRenderer: ', ipcRenderer)
     if (ipcRenderer) {
       ipcRenderer.on('file-open-error-within-electron', (event, arg) => {
         this.handleFileOpenError(arg);
@@ -248,7 +262,9 @@ class App extends Component<{}, State> {
           }
         }
       }
-      this.setState(Object.assign(initialState, stateJS, { openFiles }));
+      // Copy of initialState to enture we are not mutating it
+      const currentState = { ...initialState }
+      this.setState(Object.assign(currentState, stateJS, { openFiles }));
     }
   }
 

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -194,8 +194,8 @@ class App extends Component<{}, State> {
     const newOpenFiles = openFiles.filter(file => file != filePath);
     localStorage.removeItem(filePath);
     localStorage.removeItem('state');
-    window.d3State = setD3State({})
-    this.setState({...initialState, openFiles: newOpenFiles})
+    // window.d3State = setD3State({})
+    this.setState({...initialState, openFiles: newOpenFiles, fileOpened: false})
 
     // console.log('newOpenFiles: ', newOpenFiles)
     // console.log('length', newOpenFiles.length)

--- a/src/renderer/components/FileSelector.tsx
+++ b/src/renderer/components/FileSelector.tsx
@@ -18,6 +18,7 @@ type Props = {
 };
 
 const FileSelector: React.FC<Props> = ({ fileOpen }) => {
+  console.log('Rendering FileSelector')
   return (
     <div className="file-open">
       <label htmlFor="files">
@@ -34,10 +35,12 @@ const FileSelector: React.FC<Props> = ({ fileOpen }) => {
         style={{ display: 'none' }}
         onChange={(event: React.SyntheticEvent<HTMLInputElement>) => {
           // make sure there was something selected
+          // console.log('FileSelector Event and event.currentTarget', event, event.currentTarget)
           if (event.currentTarget) {
             // make sure user opened a file
             if (event.currentTarget.files) {
               // fire fileOpen function on first file opened
+              // console.log('Event.currentTarget.file', event.currentTarget.files[0] )
               fileOpen(event.currentTarget.files[0]);
             }
           }


### PR DESCRIPTION
For now closing a tab resets the view to the beginning state, opened file tabs still present. Can revisit this later.