### PR TITLE
added a working compose file. fixed deploy glitch

### DIFF
--- a/samples/docker-compose.working.yml
+++ b/samples/docker-compose.working.yml
@@ -1,0 +1,4 @@
+version: '3'
+services:
+  redis:
+    image: "redis:alpine"

--- a/src/renderer/components/ComposeDeployment.tsx
+++ b/src/renderer/components/ComposeDeployment.tsx
@@ -114,8 +114,7 @@ const Deployment: React.FC<Props> = ({ currentFilePath, fileOpen }) => {
     onClick = deployKill;
   } 
 
-  let inputButton = <input id='files'
-  type='file'
+  let inputButton = <input type='file'
   name='yaml'
   accept=".yml,.yaml"
   style={{ display: 'none' }}


### PR DESCRIPTION
1. added a working compose file for the demo.
2. Fixed deploy glitch: 
When the user clicked the open button in the middle of the main view it would read in the file and deploy it automatically. 
This is not part of the ComposeDeployment feature. 
The problem was with the input element in the Main View had the same id as the input button used in the ComposeDevelopment. So when the Main View Open input clicked all input buttons with the same id were invoked. 